### PR TITLE
Update official Version to v0.5.3

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -1,2 +1,2 @@
-version_name: "0.5.1"
-version_code: "1804201702"
+version_name: "0.5.3"
+version_code: "1808310314"


### PR DESCRIPTION
This updates the version of navit to v0.5.3. Which should trigger the f-Droid build once fdroid build file has been updated. Hopfully we can make this work soon...

@pgrandin this also reminds me that the playstore version on navit is not up to date (its 0.5.1)