### PR TITLE
Add  Sailfish OS

### DIFF
--- a/_data/name_mapping.yml
+++ b/_data/name_mapping.yml
@@ -25,3 +25,7 @@ build_win32:
 build_wince:
   value: WinCE
   help_text: For all devices with WinCE on it, mostly mobile devices
+  
+build_sailfish:
+  value: Sailfish OS
+  help_text: For installation on devices with Sailfish OS

--- a/_includes/build.html
+++ b/_includes/build.html
@@ -35,6 +35,9 @@
     {% if result == 'cab' %}
         <a href="{{ artifact.url }}" class="btn btn-primary mt-1">Download: {{ filename }}</a>
     {% endif %}
+    {% if result == 'rpm' %}
+        <a href="{{ artifact.url }}" class="btn btn-primary mt-1">Download: {{ filename }}</a>
+    {% endif %}
     {% if filename == 'navit.sh' or filename == 'navit.tar.gz' %}
         <a href="{{ artifact.url }}" class="btn btn-primary mt-1">Download: {{ filename }}</a>
     {% endif %}


### PR DESCRIPTION
This adds  Sailfish OS to Name Mapping so we have it automatically picked up when navit-gps/navit#679 was merged